### PR TITLE
Fix warning about CMake version not set and some unused variables.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,18 @@
+if (NOT FIPS_IMPORT)
+    cmake_minimum_required(VERSION 2.8)
+    get_filename_component(FIPS_ROOT_DIR "../fips" ABSOLUTE)
+    include("${FIPS_ROOT_DIR}/cmake/fips.cmake")
+    fips_setup()
+    fips_project(fips-glfw)
+endif()
+
 if (FIPS_MACOS OR FIPS_WINDOWS OR FIPS_LINUX)
 
     fips_begin_lib(glfw3)
-        
+
         include_directories(. glfw/src glfw/include)
         add_definitions(-D_GLFW_USE_CONFIG_H)
-        
+
         fips_files(glfw_config.h)
         fips_dir(glfw/include/GLFW)
         fips_files(glfw3.h glfw3native.h)

--- a/fips
+++ b/fips
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+"""fips main entry"""
+import os
+import sys
+import subprocess
+proj_path = os.path.dirname(os.path.abspath(__file__))
+fips_path = os.path.dirname(proj_path) + '/fips'
+if not os.path.isdir(fips_path) :
+    print("\033[93m=== cloning fips build system to '{}':\033[0m".format(fips_path))
+    subprocess.call(['git', 'clone', 'https://github.com/floooh/fips.git', fips_path]) 
+sys.path.insert(0,fips_path)
+try :
+    from mod import fips
+except ImportError :
+    print("\033[91m[ERROR]\033[0m failed to initialize fips build system in '{}'".format(proj_path)) 
+    sys.exit(10)
+fips.run(fips_path, proj_path, sys.argv)

--- a/fips.cmd
+++ b/fips.cmd
@@ -1,0 +1,2 @@
+@python fips %*
+


### PR DESCRIPTION
Also add fips and fips.cmd.
It would be nice to not need these files in each repository. Maybe we can have the fips installed on system.
Again, not sure if the best way, still learning.
