### PR TITLE
Add missing fips_finish()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,3 +59,6 @@ if (FIPS_MACOS OR FIPS_WINDOWS OR FIPS_LINUX)
     endif()
 endif()
 
+if (NOT FIPS_IMPORT)
+    fips_finish()
+endif()


### PR DESCRIPTION
I've missed this on before, adding it just to be conforming as it doesn't do anything yet.
